### PR TITLE
Fix about camera screen always black on first run of the app

### DIFF
--- a/barcode-reader/build.gradle
+++ b/barcode-reader/build.gradle
@@ -79,13 +79,13 @@ artifactory {
 
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 
@@ -115,10 +115,10 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    implementation 'com.android.support:appcompat-v7:26.0.0-beta2'
-    implementation 'com.android.support:design:26.0.0-beta2'
+    implementation 'com.android.support:appcompat-v7:27.0.0'
+    implementation 'com.android.support:design:27.0.0'
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.google.android.gms:play-services-vision:11.0.2'
-    implementation 'com.android.support:support-v4:26.0.0-beta2'
+    implementation 'com.android.support:support-v4:27.0.0'
 }

--- a/barcode-reader/src/main/java/info/androidhive/barcode/BarcodeReader.java
+++ b/barcode-reader/src/main/java/info/androidhive/barcode/BarcodeReader.java
@@ -146,9 +146,8 @@ public class BarcodeReader extends Fragment implements View.OnTouchListener, Bar
 
         final String[] permissions = new String[]{Manifest.permission.CAMERA};
 
-        if (!ActivityCompat.shouldShowRequestPermissionRationale(getActivity(),
-                Manifest.permission.CAMERA)) {
-            ActivityCompat.requestPermissions(getActivity(), permissions, RC_HANDLE_CAMERA_PERM);
+        if (shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)) {
+            requestPermissions(permissions, RC_HANDLE_CAMERA_PERM);
             return;
         }
 
@@ -157,8 +156,7 @@ public class BarcodeReader extends Fragment implements View.OnTouchListener, Bar
         View.OnClickListener listener = new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                ActivityCompat.requestPermissions(thisActivity, permissions,
-                        RC_HANDLE_CAMERA_PERM);
+                requestPermissions(permissions, RC_HANDLE_CAMERA_PERM);
             }
         };
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1"
         
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "info.androidhive.barcodereader"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,13 +21,13 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:support-v4:26.0.0-beta2'
+    implementation 'com.android.support:support-v4:27.0.0'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'com.android.support:appcompat-v7:26.0.0-beta2'
+    implementation 'com.android.support:appcompat-v7:27.0.0'
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:design:26.0.0-beta2'
+    implementation 'com.android.support:design:27.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation project(':barcode-reader')
     implementation 'com.google.android.gms:play-services-vision:11.0.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 23 15:41:37 IST 2017
+#Mon Nov 06 09:46:09 BRST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Now screen does not turn black after camera permission is granted. Moreover, Android Gradle plugin and Android API have been upgrading to their latest versions.