### PR TITLE
Helping find situations where the user might need an explanation about use of camera

### DIFF
--- a/barcode-reader/src/main/java/info/androidhive/barcode/BarcodeReader.java
+++ b/barcode-reader/src/main/java/info/androidhive/barcode/BarcodeReader.java
@@ -146,7 +146,7 @@ public class BarcodeReader extends Fragment implements View.OnTouchListener, Bar
 
         final String[] permissions = new String[]{Manifest.permission.CAMERA};
 
-        if (shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)) {
+        if (!shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)) {
             requestPermissions(permissions, RC_HANDLE_CAMERA_PERM);
             return;
         }


### PR DESCRIPTION
In pull request #6, the not operator was missing in the clause with `shouldShowRequestPermissionRationale `. Now, it works perfectly.