### PR TITLE
Fix: Fixed a bug which causes NullPointerException by calling Thread.getState()

### DIFF
--- a/barcode-reader/src/main/java/info/androidhive/barcode/camera/CameraSource.java
+++ b/barcode-reader/src/main/java/info/androidhive/barcode/camera/CameraSource.java
@@ -1097,9 +1097,7 @@ public class CameraSource {
          * Releases the underlying receiver.  This is only safe to do after the associated thread
          * has completed, which is managed in camera source's release method above.
          */
-        @SuppressLint("Assert")
         void release() {
-            assert (mProcessingThread.getState() == State.TERMINATED);
             mDetector.release();
             mDetector = null;
         }


### PR DESCRIPTION
Fixed an Issue #40 which causes "java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Thread$State java.lang.Thread.getState()' on a null object reference" by removing debug code on Production level.

Caused by we are setting the null value in ```mProcessingThread``` in ``` stop()``` function and then we call ``` release()``` Function which asserts that ```mProcessingThread``` is in **TERMINATED** state which causes the Bug because ```mProcessingThread``` is null at that time.